### PR TITLE
Fix zsh prompt setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Ensure the following software is installed on your system:
 *   **xdotool:** A command-line tool for window manipulation.
 *   **jq:** A command-line JSON processor for reading the session status.
 
+> [!NOTE]
+> The script validates that the required commands are available before it runs any
+> action. If something is missing you will see a descriptive error with the list
+> of dependencies that need to be installed.
+
 You can typically install `xdotool` and `jq` using your system's package manager:
 ```bash
 # For Debian/Ubuntu
@@ -64,6 +69,7 @@ This project consists of a single script:
     ```zsh
     # --- Miniplexer Tab Status ---
     _update_miniplexer_status() {
+      typeset -g MINIPLEXER_STATUS
       if [ -f "$HOME/.miniplexer_session.json" ]; then
         MINIPLEXER_STATUS=$(jq -r '.status' "$HOME/.miniplexer_session.json")
       else
@@ -72,6 +78,7 @@ This project consists of a single script:
     }
     autoload -U add-zsh-hook
     add-zsh-hook precmd _update_miniplexer_status
+    _update_miniplexer_status
     # --- End Miniplexer Tab Status ---
     ```
     You can then add `${MINIPLEXER_STATUS}` to your `PROMPT` variable. For example:
@@ -103,3 +110,8 @@ This project consists of a single script:
 *   **New Tab:** Use `Ctrl+Shift+T`.
 *   **Switch Tabs:** Use `Ctrl+Shift+Left` and `Ctrl+Shift+Right`.
 *   **End a session:** Run `/path/to/your/tabs.py end`. This will close all windows associated with the session.
+
+The session file keeps track of the active window and also stores a `[current/total]`
+status string under the `status` key. This value is refreshed automatically
+whenever you create, close, or switch between tabs, so your shell prompt remains
+accurate even after manually closing windows.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Miniplexer
+# Tabplexer
 
 A lightweight tab management system for terminal emulators like Alacritty that don't support native tabs. It uses `xdotool` to manage multiple terminal windows and presents them as a single, tabbed interface.
 
@@ -37,9 +37,9 @@ This project consists of a single script:
 ## Setup
 
 1.  **Place the script:**
-    Place the `tabs.py` script in a known location, for example `~/scripts/miniplexer/tabs.py`. Make sure it is executable:
+    Place the `tabs.py` script in a known location, for example `~/scripts/tabplexer/tabs.py`. Make sure it is executable:
     ```bash
-    chmod +x ~/scripts/miniplexer/tabs.py
+    chmod +x ~/scripts/tabplexer/tabs.py
     ```
 
 2.  **Configure Alacritty:**
@@ -49,17 +49,17 @@ This project consists of a single script:
     [[keyboard.bindings]]
     key = "T"
     mods = "Control|Shift"
-    command = { program = "/home/tjohnson/scripts/miniplexer/tabs.py", args = ["new"] }
+    command = { program = "~/scripts/tabplexer/tabs.py", args = ["new"] }
 
     [[keyboard.bindings]]
     key = "Right"
     mods = "Control|Shift"
-    command = { program = "/home/tjohnson/scripts/miniplexer/tabs.py", args = ["next"] }
+    command = { program = "~/scripts/tabplexer/tabs.py", args = ["next"] }
 
     [[keyboard.bindings]]
     key = "Left"
     mods = "Control|Shift"
-    command = { program = "/home/tjohnson/scripts/miniplexer/tabs.py", args = ["prev"] }
+    command = { program = "~/scripts/tabplexer/tabs.py", args = ["prev"] }
     ```
 
 3.  **Configure Your Shell Prompt (Optional):**
@@ -67,41 +67,41 @@ This project consists of a single script:
 
     **For Zsh (`~/.zshrc`):**
     ```zsh
-    # --- Miniplexer Tab Status ---
-    _update_miniplexer_status() {
-      typeset -g MINIPLEXER_STATUS
-      if [ -f "$HOME/.miniplexer_session.json" ]; then
-        MINIPLEXER_STATUS=$(jq -r '.status' "$HOME/.miniplexer_session.json")
+    # --- Tabplexer Tab Status ---
+    _update_tabplexer_status() {
+      typeset -g TABPLEXER_STATUS
+      if [ -f "$HOME/.tabplexer_session.json" ]; then
+        TABPLEXER_STATUS=$(jq -r '.status' "$HOME/.tabplexer_session.json")
       else
-        MINIPLEXER_STATUS=""
+        TABPLEXER_STATUS=""
       fi
     }
     autoload -U add-zsh-hook
-    add-zsh-hook precmd _update_miniplexer_status
-    _update_miniplexer_status
-    # --- End Miniplexer Tab Status ---
+    add-zsh-hook precmd _update_tabplexer_status
+    _update_tabplexer_status
+    # --- End Tabplexer Tab Status ---
     ```
-    You can then add `${MINIPLEXER_STATUS}` to your `PROMPT` variable. For example:
-    `PROMPT='${MINIPLEXER_STATUS} %n@%m:%~%# '`
+    You can then add `${TABPLEXER_STATUS}` to your `PROMPT` variable. For example:
+    `PROMPT='${TABPLEXER_STATUS} %n@%m:%~%# '`
 
 
     **For Bash (`~/.bashrc`):**
     ```bash
-    # --- Miniplexer Tab Status ---
-    _set_miniplexer_prompt() {
-      local MINIPLEXER_STATUS=""
-      if [ -f "$HOME/.miniplexer_session.json" ]; then
-        MINIPLEXER_STATUS=$(jq -r '.status' "$HOME/.miniplexer_session.json")
+    # --- Tabplexer Tab Status ---
+    _set_tabplexer_prompt() {
+      local TABPLEXER_STATUS=""
+      if [ -f "$HOME/.tabplexer_session.json" ]; then
+        TABPLEXER_STATUS=$(jq -r '.status' "$HOME/.tabplexer_session.json")
       fi
-      PS1="\[\033[36m\]${MINIPLEXER_STATUS}\[\033[0m\] ${ORIGINAL_PS1}"
+      PS1="\[\033[36m\]${TABPLEXER_STATUS}\[\033[0m\] ${ORIGINAL_PS1}"
     }
     if [ -z "${ORIGINAL_PS1+x}" ]; then
       ORIGINAL_PS1=$PS1
     fi
-    if [[ ! "$PROMPT_COMMAND" =~ _set_miniplexer_prompt ]]; then
-      PROMPT_COMMAND="_set_miniplexer_prompt;${PROMPT_COMMAND}"
+    if [[ ! "$PROMPT_COMMAND" =~ _set_tabplexer_prompt ]]; then
+      PROMPT_COMMAND="_set_tabplexer_prompt;${PROMPT_COMMAND}"
     fi
-    # --- End Miniplexer Tab Status ---
+    # --- End Tabplexer Tab Status ---
     ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This project consists of a single script:
     ```zsh
     # --- Tabplexer Tab Status ---
     _update_tabplexer_status() {
-      typeset -g TABPLEXER_STATUS
+      typeset -gx TABPLEXER_STATUS
       if [ -f "$HOME/.tabplexer_session.json" ]; then
         TABPLEXER_STATUS=$(jq -r '.status' "$HOME/.tabplexer_session.json")
       else
@@ -81,8 +81,25 @@ This project consists of a single script:
     _update_tabplexer_status
     # --- End Tabplexer Tab Status ---
     ```
-    You can then add `${TABPLEXER_STATUS}` to your `PROMPT` variable. For example:
-    `PROMPT='${TABPLEXER_STATUS} %n@%m:%~%# '`
+
+    *   **Using the stock Zsh prompt:** If you are not managing a custom prompt, append the status to the built-in prompt by updating `PROMPT` right after the snippet above:
+
+        ```zsh
+        PROMPT='${TABPLEXER_STATUS} '$PROMPT
+        ```
+
+        This keeps your default prompt intact while prefixing the active tab indicator.
+
+    *   **Using third-party prompts (Starship, Oh My Zsh themes, Pimp my Prompt, etc.):** Leave the `PROMPT` assignment to your theme, but expose the `TABPLEXER_STATUS` environment variable so your prompt manager can render it. For example, with Starship add this to `~/.config/starship.toml`:
+
+        ```toml
+        [custom.tabplexer]
+        command = 'echo -n ${TABPLEXER_STATUS}'
+        when = 'test -n "${TABPLEXER_STATUS}"'
+        format = '[$output ](bold cyan)'
+        ```
+
+        Then include `"$TABPLEXER_STATUS"` (or the custom module) wherever your prompt framework allows.
 
 
     **For Bash (`~/.bashrc`):**
@@ -93,6 +110,7 @@ This project consists of a single script:
       if [ -f "$HOME/.tabplexer_session.json" ]; then
         TABPLEXER_STATUS=$(jq -r '.status' "$HOME/.tabplexer_session.json")
       fi
+      export TABPLEXER_STATUS
       PS1="\[\033[36m\]${TABPLEXER_STATUS}\[\033[0m\] ${ORIGINAL_PS1}"
     }
     if [ -z "${ORIGINAL_PS1+x}" ]; then
@@ -103,6 +121,10 @@ This project consists of a single script:
     fi
     # --- End Tabplexer Tab Status ---
     ```
+
+    *   **Using the default Bash prompt:** The snippet above saves your original prompt the first time it runs and prefixes it with the Tabplexer status, so no additional changes are required.
+
+    *   **Using third-party Bash prompts (Starship, Liquid Prompt, etc.):** Keep the function so `TABPLEXER_STATUS` is refreshed, but let your prompt framework handle `PS1`. For Starship, for example, add the custom module shown in the Zsh section and reference it from your theme configuration.
 
 ## Usage
 

--- a/tabs.py
+++ b/tabs.py
@@ -7,9 +7,9 @@ import subprocess
 import time
 from pathlib import Path
 
-SESSION_FILE = Path.home() / ".miniplexer_session.json"
-WM_CLASS = "miniplexer_tab"
-LOG_FILE = Path.home() / ".miniplexer.log"
+SESSION_FILE = Path.home() / ".tabplexer_session.json"
+WM_CLASS = "tabplexer_tab"
+LOG_FILE = Path.home() / ".tabplexer.log"
 
 
 def _empty_session():

--- a/tabs.py
+++ b/tabs.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import json
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -10,25 +11,122 @@ SESSION_FILE = Path.home() / ".miniplexer_session.json"
 WM_CLASS = "miniplexer_tab"
 LOG_FILE = Path.home() / ".miniplexer.log"
 
+
+def _empty_session():
+    """Return a blank session structure."""
+    return {"windows": [], "active": None, "status": ""}
+
+
+def _format_status(windows, active):
+    """Return a `[current/total]` style status string for the prompt."""
+    if not windows:
+        return ""
+
+    try:
+        current_index = windows.index(active)
+    except ValueError:
+        current_index = 0
+
+    return f"[{current_index + 1}/{len(windows)}]"
+
+
+def _normalize_session(data, available_windows=None):
+    """Sanitize session data, dropping stale windows and fixing the status."""
+    session = _empty_session()
+
+    windows = []
+    seen = set()
+    desired_windows = data.get("windows") or []
+    for window_id in desired_windows:
+        try:
+            w_id = int(window_id)
+        except (TypeError, ValueError):
+            continue
+
+        if available_windows is not None and w_id not in available_windows:
+            continue
+
+        if w_id in seen:
+            continue
+
+        seen.add(w_id)
+        windows.append(w_id)
+
+    session["windows"] = windows
+
+    active = data.get("active")
+    try:
+        active = int(active) if active is not None else None
+    except (TypeError, ValueError):
+        active = None
+
+    if windows:
+        if active not in windows:
+            active = windows[0]
+
+        session["active"] = active
+        session["status"] = _format_status(windows, active)
+
+    return session
+
+COMMAND_DEPENDENCIES = {
+    "start": {"alacritty", "xdotool"},
+    "new": {"alacritty", "xdotool"},
+    "next": {"xdotool"},
+    "prev": {"xdotool"},
+    "end": {"xdotool"},
+}
+
+
+def missing_dependencies(required_commands):
+    """Return a sorted list of missing external commands."""
+    missing = []
+    for command in sorted(required_commands):
+        if shutil.which(command) is None:
+            missing.append(command)
+    return missing
+
+
+def ensure_dependencies(command):
+    """Validate that all required external commands exist for the given action."""
+    required = COMMAND_DEPENDENCIES.get(command, set())
+    missing = missing_dependencies(required)
+    if missing:
+        deps = ", ".join(missing)
+        print(
+            "Cannot continue because the following dependencies are missing: "
+            f"{deps}."
+        )
+        print("Please install them and try again.")
+        sys.exit(1)
+
 def log_message(message):
     """Appends a message to the log file."""
     with open(LOG_FILE, "a") as f:
         f.write(f"[{time.time()}] {message}\n")
 
-def read_session():
-    """Reads the session file and returns the data."""
+def read_session(available_windows=None):
+    """Reads the session file, pruning stale windows along the way."""
+    if available_windows is None:
+        available_windows = set(find_windows())
+
     if not SESSION_FILE.exists():
-        return {"windows": [], "active": None}
+        return _normalize_session(_empty_session(), available_windows)
+
     with open(SESSION_FILE, "r") as f:
         try:
-            return json.load(f)
+            raw_session = json.load(f)
         except json.JSONDecodeError:
-            return {"windows": [], "active": None}
+            raw_session = _empty_session()
+
+    return _normalize_session(raw_session, available_windows)
 
 def write_session(data):
     """Writes the given data to the session file."""
+    session = _normalize_session(data)
     with open(SESSION_FILE, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump(session, f, indent=2)
+    return session
 
 
 
@@ -81,7 +179,8 @@ def handle_start():
 def handle_new():
     """Creates a new tab."""
     log_message("--- handle_new called ---")
-    session = read_session()
+    windows_before = set(find_windows())
+    session = read_session(windows_before)
     log_message(f"Initial session: {session}")
 
     if not session.get("windows"):
@@ -90,7 +189,6 @@ def handle_new():
         return
 
     active_window = session.get("active")
-    windows_before = set(find_windows())
     log_message(f"Windows before launch: {windows_before}")
 
     log_message("Launching new terminal...")
@@ -118,8 +216,8 @@ def handle_new():
 
     session["windows"].append(new_window)
     session["active"] = new_window
+    session = write_session(session)
     log_message(f"Writing new session: {session}")
-    write_session(session)
     log_message("--- handle_new finished ---")
     print(f"New tab created with window {new_window}")
 
@@ -167,6 +265,7 @@ def handle_prev():
     new_active = windows[prev_idx]
     _switch_to_window(active, new_active)
 
+    session["active"] = new_active
     write_session(session)
 
 def handle_end():
@@ -184,10 +283,10 @@ def main():
     """Main entry point."""
     if len(sys.argv) == 1:
         # If no command, default to starting a session
-        handle_start()
-        return
+        command = "start"
+    else:
+        command = sys.argv[1]
 
-    command = sys.argv[1]
     commands = {
         "start": handle_start,
         "new": handle_new,
@@ -197,6 +296,7 @@ def main():
     }
 
     if command in commands:
+        ensure_dependencies(command)
         commands[command]()
     else:
         print(f"Unknown command: {command}")


### PR DESCRIPTION
## Summary
- ensure the README's zsh snippet exports MINIPLEXER_STATUS so PROMPT updates work
- run the updater once during shell initialization to populate the first prompt

## Testing
- python -m compileall tabs.py

------
https://chatgpt.com/codex/tasks/task_e_68e431a7e0048324a0eefaea0469aba4